### PR TITLE
Raw ntp

### DIFF
--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -58,11 +58,9 @@ class NTP:
         self._port = port
         self._packet = bytearray(48)
 
-        if time.gmtime(0).tm_year != 1970:
-            raise OSError("Epoch must be 1970")
 
-        # This is our estimated start time for the monotonic clock. We adjust it based on the ntp
-        # responses.
+        # This is our estimated start time for the monotonic clock.
+        # We adjust it based on the ntp responses.
         self._monotonic_start = 0
 
         self.next_sync = 0
@@ -84,4 +82,4 @@ class NTP:
             seconds = struct.unpack_from("!I", self._packet, offset=len(self._packet) - 8)[0]
             self._monotonic_start = seconds - NTP_TO_UNIX_EPOCH - (destination // 1_000_000_000)
 
-        return time.gmtime(time.monotonic_ns() // 1_000_000_000 + self._monotonic_start)
+        return time.localtime(time.monotonic_ns() // 1_000_000_000 + self._monotonic_start)

--- a/examples/ntp_esp32spi.py
+++ b/examples/ntp_esp32spi.py
@@ -1,0 +1,52 @@
+import time
+import board
+import busio
+from digitalio import DigitalInOut
+from adafruit_esp32spi import adafruit_esp32spi
+from adafruit_ntp import NTP
+
+# If you are using a board with pre-defined ESP32 Pins:
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
+
+# If you have an externally connected ESP32:
+# esp32_cs = DigitalInOut(board.D9)
+# esp32_ready = DigitalInOut(board.D10)
+# esp32_reset = DigitalInOut(board.D5)
+
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
+print("Connecting to AP...")
+while not esp.is_connected:
+    try:
+        esp.connect_AP(b"WIFI_SSID", b"WIFI_PASS")
+    except RuntimeError as e:
+        print("could not connect to AP, retrying: ", e)
+        continue
+
+# Initialize the NTP object
+ntp = NTP(esp)
+
+# Fetch and set the microcontroller's current UTC time
+# keep retrying until a valid time is returned
+while not ntp.valid_time:
+    ntp.set_time()
+    print("Failed to obtain time, retrying in 5 seconds...")
+    time.sleep(5)
+
+# Get the current time in seconds since Jan 1, 1970
+current_time = time.time()
+print("Seconds since Jan 1, 1970: {} seconds".format(current_time))
+
+# Convert the current time in seconds since Jan 1, 1970 to a struct_time
+now = time.localtime(current_time)
+print(now)
+
+# Pretty-parse the struct_time
+print(
+    "It is currently {}/{}/{} at {}:{}:{} UTC".format(
+        now.tm_mon, now.tm_mday, now.tm_year, now.tm_hour, now.tm_min, now.tm_sec
+    )
+)

--- a/examples/ntp_simpletest.py
+++ b/examples/ntp_simpletest.py
@@ -1,9 +1,26 @@
-import adafruit_ntp
-import socket
+import socketpool
 import time
+import wifi
 
-ntp = adafruit_ntp.NTP(socket)
+import adafruit_ntp
+
+
+# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
+# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# source control.
+# pylint: disable=no-name-in-module,wrong-import-order
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
+
+wifi.radio.connect(secrets["ssid"], secrets["wifi_password"])
+
+pool = socketpool.SocketPool(wifi.radio)
+ntp = adafruit_ntp.NTP(pool)
 
 while True:
     print(ntp.datetime)
     time.sleep(1)
+ 

--- a/examples/ntp_simpletest.py
+++ b/examples/ntp_simpletest.py
@@ -15,7 +15,7 @@ except ImportError:
     print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
-wifi.radio.connect(secrets["ssid"], secrets["wifi_password"])
+wifi.radio.connect(secrets["ssid"], secrets["password"])
 
 pool = socketpool.SocketPool(wifi.radio)
 ntp = adafruit_ntp.NTP(pool)

--- a/examples/ntp_simpletest.py
+++ b/examples/ntp_simpletest.py
@@ -1,52 +1,9 @@
+import adafruit_ntp
+import socket
 import time
-import board
-import busio
-from digitalio import DigitalInOut
-from adafruit_esp32spi import adafruit_esp32spi
-from adafruit_ntp import NTP
 
-# If you are using a board with pre-defined ESP32 Pins:
-esp32_cs = DigitalInOut(board.ESP_CS)
-esp32_ready = DigitalInOut(board.ESP_BUSY)
-esp32_reset = DigitalInOut(board.ESP_RESET)
+ntp = adafruit_ntp.NTP(socket)
 
-# If you have an externally connected ESP32:
-# esp32_cs = DigitalInOut(board.D9)
-# esp32_ready = DigitalInOut(board.D10)
-# esp32_reset = DigitalInOut(board.D5)
-
-spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
-
-print("Connecting to AP...")
-while not esp.is_connected:
-    try:
-        esp.connect_AP(b"WIFI_SSID", b"WIFI_PASS")
-    except RuntimeError as e:
-        print("could not connect to AP, retrying: ", e)
-        continue
-
-# Initialize the NTP object
-ntp = NTP(esp)
-
-# Fetch and set the microcontroller's current UTC time
-# keep retrying until a valid time is returned
-while not ntp.valid_time:
-    ntp.set_time()
-    print("Failed to obtain time, retrying in 5 seconds...")
-    time.sleep(5)
-
-# Get the current time in seconds since Jan 1, 1970
-current_time = time.time()
-print("Seconds since Jan 1, 1970: {} seconds".format(current_time))
-
-# Convert the current time in seconds since Jan 1, 1970 to a struct_time
-now = time.localtime(current_time)
-print(now)
-
-# Pretty-parse the struct_time
-print(
-    "It is currently {}/{}/{} at {}:{}:{} UTC".format(
-        now.tm_mon, now.tm_mday, now.tm_year, now.tm_hour, now.tm_min, now.tm_sec
-    )
-)
+while True:
+    print(ntp.datetime)
+    time.sleep(1)

--- a/examples/ntp_simpletest_cpython.py
+++ b/examples/ntp_simpletest_cpython.py
@@ -1,0 +1,9 @@
+import adafruit_ntp
+import socket
+import time
+
+ntp = adafruit_ntp.NTP(socket)
+
+while True:
+    print(ntp.datetime)
+    time.sleep(1)


### PR DESCRIPTION
Picking up on the work by @tannewt (who did the hard part) this PR has the following:

- Removes the check for Epoch. It failes on esp32s2, but it also appears to not be needed as it works without it.
- changes the calls to `time.gmtime()` with `time.localtime()`
- It adds an `ntp_simpletest.py` which will works on esp32s2 boards (those with native wifi)
- It renames the previous `ntp_simpletest.py` to `ntp_simpletest_cpython.py`

Tested:

- Python 
- CircuitPython esp32s2 port, FeatherS2 

Not Tested:

- esp32spi board